### PR TITLE
[FIX] 좋아요 취소 안되는 이슈 수정

### DIFF
--- a/src/main/java/com/study/totee/api/controller/PostController.java
+++ b/src/main/java/com/study/totee/api/controller/PostController.java
@@ -120,7 +120,6 @@ public class PostController {
         return ApiResponse.success("data", page);
     }
 
-
     @ApiOperation(value = "post 상세보기",
             notes = "PostId로 상세보기\n" +
                     "api 주소에 PathVariable 주면 됩니다.")

--- a/src/main/java/com/study/totee/api/persistence/LikeRepository.java
+++ b/src/main/java/com/study/totee/api/persistence/LikeRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
-    Like findByUser_IdAndPost_Id(String userId, Long postId);
+    Like findByUser_IdAndPost_Id(Long userId, Long postId);
 }

--- a/src/main/java/com/study/totee/api/service/LikeService.java
+++ b/src/main/java/com/study/totee/api/service/LikeService.java
@@ -35,7 +35,7 @@ public class LikeService {
         Post post = postRepository.findById(postId).orElseThrow(
                 ()-> new BadRequestException(ErrorCode.NO_POST_ERROR));
 
-        Like like = likeRepository.findByUser_IdAndPost_Id(userId , postId);
+        Like like = likeRepository.findByUser_IdAndPost_Id(user.getUserSeq() , postId);
 
         if(like == null){
             post.increaseLikeNum();
@@ -57,10 +57,12 @@ public class LikeService {
 
     @Transactional(readOnly = true)
     public boolean isLike(String userId, Long postId){
+        User user = Optional.ofNullable(userRepository.findById(userId)).orElseThrow(
+                ()-> new BadRequestException(ErrorCode.NOT_EXIST_USER_ERROR));
         postRepository.findById(postId).orElseThrow(
                 ()-> new BadRequestException(ErrorCode.NO_POST_ERROR));
 
-        Like like = likeRepository.findByUser_IdAndPost_Id(userId , postId);
+        Like like = likeRepository.findByUser_IdAndPost_Id(user.getUserSeq() , postId);
         return like != null;
     }
 


### PR DESCRIPTION
javax.persistence.NonUniqueResultException: query did not return a unique result: 24

하나가 아닌 다수가 조회가 되어 좋아요 취소가 안되는 이유였습니다.
